### PR TITLE
@sorear mentioned that `unpair` was broken when `out2 = t0`.

### DIFF
--- a/zf.nql
+++ b/zf.nql
@@ -10,16 +10,18 @@ proc pair(out, in1, in2) {
 }
 
 proc unpair(out1, out2, in) {
+    /* NB out2 can be aliased to t0 */
+    /* NB out1 can be aliased to in */
     t0 = 0;
     t1 = 0; /* invariant: t1 = t0 * (t0 + 1) / 2 */
     while (in >= t1) {
         t0 = t0 + 1;
         t1 = t1 + t0;
     }
-    t1 = t1 - t0;
+    t1 = t1 - 1;
     t0 = t0 - 1;
-    out2 = in - t1;
-    out1 = t0 - out2;
+    out1 = t1 - in;
+    out2 = t0 - out1;
 }
 
 proc push(stack, var) { pair(stack, var, stack); }
@@ -48,8 +50,8 @@ proc car() {
 }
 proc cdr() {
     pop(t2, wstack);
-    unpair(t0, t2, t2);
-    push(wstack, t2);
+    unpair(t2, t0, t2);
+    push(wstack, t0);
 }
 proc cddr() { cdr(); cdr(); }
 proc cadr() { cdr(); car(); }


### PR DESCRIPTION
This change fixes `unpair` in all of the alias situations which arise, and also saves a few states.
Down to 1883, or 1879 with --no-cfg-optimize
